### PR TITLE
feat: add subcategory selection to product forms

### DIFF
--- a/src/views/EditProduct.vue
+++ b/src/views/EditProduct.vue
@@ -178,7 +178,7 @@ export default {
         if (Array.isArray(this.product.tags)) {
           this.product.tags = this.product.tags.join(', ');
         }
-        const catEntry = this.categories.find(c => c.name.toLowerCase() === data.category?.toLowerCase());
+        const catEntry = this.categories.find(c => c.name.split('/')[0].trim().toLowerCase() === data.category?.toLowerCase());
         if (catEntry) {
           this.product.category = catEntry.id;
           await this.fetchTypesForCategory(catEntry.id);
@@ -236,10 +236,9 @@ export default {
     async saveProduct() {
       const productRef = doc(db, `users/${this.product.sellerId}/products/${this.product.id}`);
       const categoryObj = this.categories.find(c => c.id === this.product.category);
-      const rawCategory = categoryObj ? categoryObj.name : this.product.category;
-      const formattedCategory = rawCategory
-        ? rawCategory.charAt(0).toUpperCase() + rawCategory.slice(1)
-        : '';
+      let rawCategory = categoryObj ? categoryObj.name : this.product.category;
+      rawCategory = rawCategory.split('/')[0].trim();
+      const formattedCategory = this.capitalize(rawCategory);
       const tags = Array.isArray(this.product.tags)
         ? this.product.tags
         : (this.product.tags || '')

--- a/src/views/EditProduct.vue
+++ b/src/views/EditProduct.vue
@@ -236,7 +236,10 @@ export default {
     async saveProduct() {
       const productRef = doc(db, `users/${this.product.sellerId}/products/${this.product.id}`);
       const categoryObj = this.categories.find(c => c.id === this.product.category);
-      const categoryName = categoryObj ? categoryObj.name : this.capitalize(this.product.category);
+      const rawCategory = categoryObj ? categoryObj.name : this.product.category;
+      const formattedCategory = rawCategory
+        ? rawCategory.charAt(0).toUpperCase() + rawCategory.slice(1)
+        : '';
       const tags = Array.isArray(this.product.tags)
         ? this.product.tags
         : (this.product.tags || '')
@@ -245,7 +248,7 @@ export default {
             .filter(t => t);
       await updateDoc(productRef, {
         ...this.product,
-        category: categoryName,
+        category: formattedCategory,
         tags,
       });
       alert('Product updated successfully!');

--- a/src/views/NewProduct.vue
+++ b/src/views/NewProduct.vue
@@ -25,7 +25,7 @@
             <label>Type:</label>
               <select v-model="product.type" class="colored-field">
                 <option disabled value="">Select Type</option>
-                <option v-for="type in types" :key="type.id" :value="type.id">{{ type.name }}</option>
+                <option v-for="type in types" :key="type.id" :value="type.name">{{ type.name }}</option>
               </select>
           </div>
         </div>
@@ -35,7 +35,7 @@
             <label>Subcategory:</label>
             <select v-model="product.subcategory" class="colored-field">
               <option disabled value="">Select Subcategory</option>
-              <option v-for="sub in subcategories" :key="sub.id" :value="sub.id">{{ sub.name }}</option>
+              <option v-for="sub in subcategories" :key="sub.id" :value="sub.name">{{ sub.name }}</option>
             </select>
           </div>
         </div>
@@ -166,17 +166,30 @@ export default {
     };
   },
   watch: {
-    'product.category'(newCategoryId) {
-      this.product.type = '';
-      this.product.subcategory = '';
-      this.subcategories = [];
-      if (newCategoryId) this.fetchTypesForCategory(newCategoryId);
-      else this.types = [];
+    'product.category'(newCategoryId, oldCategoryId) {
+      if (newCategoryId) {
+        this.fetchTypesForCategory(newCategoryId);
+        if (oldCategoryId) {
+          this.product.type = '';
+          this.product.subcategory = '';
+          this.subcategories = [];
+        }
+      } else {
+        this.types = [];
+        this.subcategories = [];
+        this.product.type = '';
+        this.product.subcategory = '';
+      }
     },
-    'product.type'(newTypeId) {
-      this.product.subcategory = '';
-      if (newTypeId) this.fetchSubCategories(this.product.category, newTypeId);
-      else this.subcategories = [];
+    'product.type'(newTypeName, oldTypeName) {
+      const typeObj = this.types.find(t => t.name === newTypeName);
+      if (typeObj) {
+        this.fetchSubCategories(this.product.category, typeObj.id);
+        if (oldTypeName) this.product.subcategory = '';
+      } else {
+        this.subcategories = [];
+        this.product.subcategory = '';
+      }
     }
   },
   methods: {

--- a/src/views/NewProduct.vue
+++ b/src/views/NewProduct.vue
@@ -266,10 +266,9 @@ async submitProduct() {
 
   const ref = doc(db, `users/${this.product.sellerId}/products/${productId}`);
   const categoryObj = this.categories.find(c => c.id === this.product.category);
-  const rawCategory = categoryObj ? categoryObj.name : this.product.category;
-  const formattedCategory = rawCategory
-    ? rawCategory.charAt(0).toUpperCase() + rawCategory.slice(1)
-    : '';
+  let rawCategory = categoryObj ? categoryObj.name : this.product.category;
+  rawCategory = rawCategory.split('/')[0].trim();
+  const formattedCategory = this.capitalize(rawCategory);
   await setDoc(ref, {
     ...this.product,
     category: formattedCategory,
@@ -293,10 +292,9 @@ async saveAndAddAnother() {
 
   const ref = doc(db, `users/${this.product.sellerId}/products/${productId}`);
   const categoryObj = this.categories.find(c => c.id === this.product.category);
-  const rawCategory = categoryObj ? categoryObj.name : this.product.category;
-  const formattedCategory = rawCategory
-    ? rawCategory.charAt(0).toUpperCase() + rawCategory.slice(1)
-    : '';
+  let rawCategory = categoryObj ? categoryObj.name : this.product.category;
+  rawCategory = rawCategory.split('/')[0].trim();
+  const formattedCategory = this.capitalize(rawCategory);
   await setDoc(ref, {
     ...this.product,
     category: formattedCategory,

--- a/src/views/NewProduct.vue
+++ b/src/views/NewProduct.vue
@@ -265,9 +265,14 @@ async submitProduct() {
   if (!this.product.sellerId) return alert("Please select a seller");
 
   const ref = doc(db, `users/${this.product.sellerId}/products/${productId}`);
+  const categoryObj = this.categories.find(c => c.id === this.product.category);
+  const rawCategory = categoryObj ? categoryObj.name : this.product.category;
+  const formattedCategory = rawCategory
+    ? rawCategory.charAt(0).toUpperCase() + rawCategory.slice(1)
+    : '';
   await setDoc(ref, {
     ...this.product,
-    category: (this.categories.find(c => c.id === this.product.category)?.name) || this.capitalize(this.product.category),
+    category: formattedCategory,
     createdAt: serverTimestamp(),
     salesCount: 0,
     totalQuantity: null,
@@ -287,9 +292,14 @@ async saveAndAddAnother() {
   if (!this.product.sellerId) return alert("Please select a seller");
 
   const ref = doc(db, `users/${this.product.sellerId}/products/${productId}`);
+  const categoryObj = this.categories.find(c => c.id === this.product.category);
+  const rawCategory = categoryObj ? categoryObj.name : this.product.category;
+  const formattedCategory = rawCategory
+    ? rawCategory.charAt(0).toUpperCase() + rawCategory.slice(1)
+    : '';
   await setDoc(ref, {
     ...this.product,
-    category: (this.categories.find(c => c.id === this.product.category)?.name) || this.capitalize(this.product.category),
+    category: formattedCategory,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
     salesCount: 0,

--- a/src/views/NewProduct.vue
+++ b/src/views/NewProduct.vue
@@ -193,11 +193,14 @@ export default {
     }
   },
   methods: {
+    capitalize(str) {
+      return str ? str.charAt(0).toUpperCase() + str.slice(1) : '';
+    },
     async fetchCategories() {
       const snap = await getDocs(collection(db, 'categories'));
       this.categories = snap.docs.map(doc => ({
         id: doc.id,
-        name: doc.data().name
+        name: this.capitalize(doc.data().name)
       }));
     },
 
@@ -264,6 +267,7 @@ async submitProduct() {
   const ref = doc(db, `users/${this.product.sellerId}/products/${productId}`);
   await setDoc(ref, {
     ...this.product,
+    category: (this.categories.find(c => c.id === this.product.category)?.name) || this.capitalize(this.product.category),
     createdAt: serverTimestamp(),
     salesCount: 0,
     totalQuantity: null,
@@ -285,6 +289,7 @@ async saveAndAddAnother() {
   const ref = doc(db, `users/${this.product.sellerId}/products/${productId}`);
   await setDoc(ref, {
     ...this.product,
+    category: (this.categories.find(c => c.id === this.product.category)?.name) || this.capitalize(this.product.category),
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
     salesCount: 0,


### PR DESCRIPTION
## Summary
- add subcategory dropdown fed from Firestore in new/edit product pages
- load subcategories dynamically based on chosen category and type

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895bae557648331889e51dc4d9118a1